### PR TITLE
all 4 scenarios now working with localproxy too

### DIFF
--- a/Source/Csla.AspNetCore/Blazor/ApplicationContextManagerBlazor.cs
+++ b/Source/Csla.AspNetCore/Blazor/ApplicationContextManagerBlazor.cs
@@ -109,11 +109,7 @@ namespace Csla.AspNetCore.Blazor
       get { return ActiveCircuitState.CircuitExists; }
     }
 
-    /// <summary>
-    /// Gets a value indicating whether the current runtime
-    /// is stateful (e.g. WPF, Blazor, etc.)
-    /// </summary>
-    public bool IsStatefulRuntime => true;
+    public bool IsStatefulContext => true;
 
     /// <summary>
     /// Gets the current principal.

--- a/Source/Csla.AspNetCore/ConfigurationExtensions.cs
+++ b/Source/Csla.AspNetCore/ConfigurationExtensions.cs
@@ -49,9 +49,6 @@ namespace Csla.Configuration
       config.Services.AddScoped(typeof(IContextManager), typeof(ApplicationContextManagerBlazor));
 #endif
       config.Services.AddScoped(typeof(IContextManager), typeof(ApplicationContextManagerHttpContext));
-      config.Services.AddScoped(
-        typeof(IRuntimeInfo),
-        (p) => new RuntimeInfo { IsHttpContextValid = true, IsStatefulRuntime = false });
       return config;
     }
   }

--- a/Source/Csla.Blazor.WebAssembly/ApplicationContextManager.cs
+++ b/Source/Csla.Blazor.WebAssembly/ApplicationContextManager.cs
@@ -79,7 +79,7 @@ namespace Csla.Blazor.WebAssembly
     /// Gets a value indicating whether the current runtime
     /// is stateful (e.g. WPF, Blazor, etc.)
     /// </summary>
-    public bool IsStatefulRuntime => true;
+    public bool IsStatefulContext => true;
 
     /// <summary>
     /// Gets the current principal.

--- a/Source/Csla.Blazor/ConfigurationExtensions.cs
+++ b/Source/Csla.Blazor/ConfigurationExtensions.cs
@@ -41,10 +41,6 @@ namespace Csla.Configuration
       var blazorOptions = new BlazorServerConfigurationOptions();
       options?.Invoke(blazorOptions);
 
-      config.Services.AddScoped(
-        typeof(IRuntimeInfo),
-        (p) => new RuntimeInfo { IsHttpContextValid = false, IsStatefulRuntime = true });
-
       // use Blazor viewmodel
       config.Services.TryAddTransient(typeof(ViewModel<>), typeof(ViewModel<>));
       if (blazorOptions.UseCslaPermissionsPolicy)

--- a/Source/Csla.Web.Mvc.Shared/ApplicationContextManager.cs
+++ b/Source/Csla.Web.Mvc.Shared/ApplicationContextManager.cs
@@ -34,7 +34,7 @@ namespace Csla.Web.Mvc
     /// Gets a value indicating whether the current runtime
     /// is stateful (e.g. WPF, Blazor, etc.)
     /// </summary>
-    public bool IsStatefulRuntime => false;
+    public bool IsStatefulContext => false;
 
     /// <summary>
     /// Gets the current principal.

--- a/Source/Csla.Web/ApplicationContextManager.cs
+++ b/Source/Csla.Web/ApplicationContextManager.cs
@@ -39,7 +39,7 @@ namespace Csla.Web
     /// Gets a value indicating whether the current runtime
     /// is stateful (e.g. WPF, Blazor, etc.)
     /// </summary>
-    public bool IsStatefulRuntime => false;
+    public bool IsStatefulContext => false;
 
     /// <summary>
     /// Gets the current principal.

--- a/Source/Csla/ApplicationContext.cs
+++ b/Source/Csla/ApplicationContext.cs
@@ -372,10 +372,11 @@ namespace Csla
     #endregion
 
     /// <summary>
-    /// Gets a value indicating whether the current runtime
-    /// is stateful (e.g. WPF, Blazor, etc.)
+    /// Gets a value indicating whether the current 
+    /// context manager is used in a stateful
+    /// context (e.g. WPF, Blazor, etc.)
     /// </summary>
-    public bool IsStatefulRuntime => RuntimeInfo.IsStatefulRuntime;
+    public bool IsAStatefulContextManager => ContextManager.IsStatefulContext;
 
     private IServiceProvider _serviceProvider;
 

--- a/Source/Csla/Configuration/ConfigurationExtensions.cs
+++ b/Source/Csla/Configuration/ConfigurationExtensions.cs
@@ -48,9 +48,7 @@ namespace Csla.Configuration
       RegisterContextManager(services);
 
       // Runtime Info defaults
-      services.TryAddScoped(
-        typeof(IRuntimeInfo), 
-        (p) => new RuntimeInfo { IsHttpContextValid = false, IsStatefulRuntime = true });
+      services.TryAddScoped(typeof(IRuntimeInfo), typeof(RuntimeInfo));
 
       cslaOptions.AddRequiredDataPortalServices();
 

--- a/Source/Csla/Core/ApplicationContextManager.cs
+++ b/Source/Csla/Core/ApplicationContextManager.cs
@@ -20,6 +20,8 @@ namespace Csla.Core
     private readonly AsyncLocal<ContextDictionary> _localContext = new();
     private readonly AsyncLocal<ContextDictionary> _clientContext = new();
 
+    public bool IsStatefulContext => true;
+
     /// <summary>
     /// Returns a value indicating whether the context is valid.
     /// </summary>

--- a/Source/Csla/Core/ApplicationContextManagerAsyncLocal.cs
+++ b/Source/Csla/Core/ApplicationContextManagerAsyncLocal.cs
@@ -20,6 +20,8 @@ namespace Csla.Core
     private readonly AsyncLocal<ContextDictionary> _clientContext = new();
     private readonly AsyncLocal<IPrincipal> _principal = new();
 
+    public bool IsStatefulContext => true;
+
     /// <summary>
     /// Returns a value indicating whether the context is valid.
     /// </summary>

--- a/Source/Csla/Core/ApplicationContextManagerStatic.cs
+++ b/Source/Csla/Core/ApplicationContextManagerStatic.cs
@@ -19,6 +19,8 @@ namespace Csla.Core
   /// </summary>
   public class ApplicationContextManagerStatic : Csla.Core.IContextManager
   {
+    public bool IsStatefulContext => true;
+
     /// <summary>
     /// Returns a value indicating whether the context is valid.
     /// </summary>

--- a/Source/Csla/Core/ApplicationContextManagerTls.cs
+++ b/Source/Csla/Core/ApplicationContextManagerTls.cs
@@ -31,6 +31,8 @@ namespace Csla.Core
       _provider = provider;
     }
 
+    public bool IsStatefulContext => true;
+
     /// <summary>
     /// Returns a value indicating whether the context is valid.
     /// </summary>

--- a/Source/Csla/Core/IContextManager.cs
+++ b/Source/Csla/Core/IContextManager.cs
@@ -17,6 +17,13 @@ namespace Csla.Core
   public interface IContextManager
   {
     /// <summary>
+    /// Gets a value indicating whether this  
+    /// context manager is used in a stateful
+    /// context (e.g. WPF, Blazor, etc.)
+    /// </summary>
+    bool IsStatefulContext { get; }
+
+    /// <summary>
     /// Gets a value indicating whether this
     /// context manager is valid for use in
     /// the current environment.

--- a/Source/Csla/DataPortalClient/LocalProxy.cs
+++ b/Source/Csla/DataPortalClient/LocalProxy.cs
@@ -33,7 +33,7 @@ namespace Csla.Channels.Local
       Options = options;
 
       if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client 
-        && ApplicationContext.IsStatefulRuntime)
+        && ApplicationContext.IsAStatefulContextManager)
       {
         // create new DI scope and provider
         _scope = ApplicationContext.CurrentServiceProvider.CreateScope();
@@ -43,8 +43,7 @@ namespace Csla.Channels.Local
         // data portal operation, so this "runtime" is stateless and
         // we can't count on HttpContext
         var runtimeInfo = provider.GetRequiredService<IRuntimeInfo>();
-        runtimeInfo.IsStatefulRuntime = false;
-        runtimeInfo.IsHttpContextValid = false;
+        runtimeInfo.LocalProxyNewScopeExists = true;
       }
 
       _portal = provider.GetRequiredService<Server.IDataPortalServer>();
@@ -190,7 +189,7 @@ namespace Csla.Channels.Local
         if (disposing)
         {
           if (ApplicationContext.LogicalExecutionLocation == ApplicationContext.LogicalExecutionLocations.Client
-            && ApplicationContext.IsStatefulRuntime)
+            && ApplicationContext.IsAStatefulContextManager)
           {
             _scope?.Dispose();
           }

--- a/Source/Csla/Runtime/IRuntimeInfo.cs
+++ b/Source/Csla/Runtime/IRuntimeInfo.cs
@@ -13,15 +13,10 @@ namespace Csla.Runtime
   public interface IRuntimeInfo
   {
     /// <summary>
-    /// Gets a value indicating whether the current runtime
-    /// is stateful (like WPF, Blazor, etc.).
+    /// Gets a value indicating whether a LocalProxy (if configured and used)
+    /// has created a new scope in preparation for logical server side
+    /// operations.
     /// </summary>
-    bool IsStatefulRuntime { get; set; }
-    /// <summary>
-    /// Gets a valud indicating whether any HttpContext instance
-    /// can be considered valid (false for all server-side Blazor
-    /// scenarios).
-    /// </summary>
-    bool IsHttpContextValid { get; set; }
+    bool LocalProxyNewScopeExists { get; set; }
   }
 }

--- a/Source/Csla/Runtime/RuntimeInfo.cs
+++ b/Source/Csla/Runtime/RuntimeInfo.cs
@@ -12,17 +12,6 @@ namespace Csla.Runtime
   /// </summary>
   public class RuntimeInfo : IRuntimeInfo
   {
-    /// <summary>
-    /// Gets a value indicating whether the current runtime
-    /// is stateful (like WPF, Blazor, etc.).
-    /// </summary>
-    public bool IsStatefulRuntime { get; set; }
-
-    /// <summary>
-    /// Gets a valud indicating whether any HttpContext instance
-    /// can be considered valid (false for all server-side Blazor
-    /// scenarios).
-    /// </summary>
-    public bool IsHttpContextValid { get; set; }
+    public bool LocalProxyNewScopeExists { get; set; }
   }
 }


### PR DESCRIPTION
#2798  Building on your work in your branch 2798-localproxy.  Your latest technique did not work with razor pages (.cshtml) because of the way things were set in the `ConfigurationExtensions` to favor blazor.  But your code caused me to see how it could work with fairly minor tweak.  Here it is: 


- all scenarios work - calls to bl from a hosted service, cshtml pages, and razor pages while properly adapting during `LocalProxy` new scope;  
- the `ApplicationContextManagerHttpContext` knows it's NOT valid if a circuit exists or also if a localproxy scope was created;
- simplified the `IRuntimeInfo` to only track a bool indicating if LocalProxy scope has been created;
- `ConfigurationExtensions` for AspNetCore and Blazor no longer fight with each other;

I tested every combination and all looks good.  Let me know what you think.
