### PR TITLE
#2798 some tweaks to appcontext tests for blazor;

### DIFF
--- a/Source/Csla.Blazor.Test/ApplicationContextTests.cs
+++ b/Source/Csla.Blazor.Test/ApplicationContextTests.cs
@@ -5,6 +5,8 @@ using Csla.Configuration;
 using Csla.Core;
 using Microsoft.AspNetCore.Components.Authorization;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Csla.Blazor.Test
 {
@@ -20,10 +22,28 @@ namespace Csla.Blazor.Test
       services.AddScoped<Csla.AspNetCore.Blazor.ActiveCircuitState>();
       services.AddScoped(typeof(AuthenticationStateProvider), typeof(TestAuthenticationStateProvider));
       services.AddCsla(c => c
-        .AddServerSideBlazor());
+        .AddAspNetCore()
+        .AddServerSideBlazor()
+      );
       IServiceProvider provider = services.BuildServiceProvider();
-      var manager = provider.GetRequiredService<IContextManager>();
-      Assert.IsInstanceOfType(manager, typeof(Csla.AspNetCore.ApplicationContextManager));
+      var managers = provider.GetRequiredService<IEnumerable<IContextManager>>();
+      Assert.IsTrue(managers.Count() == 2);
+      var blazorMgr = (Csla.AspNetCore.Blazor.ApplicationContextManagerBlazor)managers.FirstOrDefault(mgr => mgr is Csla.AspNetCore.Blazor.ApplicationContextManagerBlazor);
+      var httpMgr = (Csla.AspNetCore.ApplicationContextManagerHttpContext)managers.FirstOrDefault(mgr => mgr is Csla.AspNetCore.ApplicationContextManagerHttpContext);
+      Assert.IsNotNull(blazorMgr);
+      Assert.IsTrue(blazorMgr.IsStatefulContext);
+      Assert.IsFalse(blazorMgr.IsValid); //because no circuit exists
+
+
+      Assert.IsNotNull(httpMgr);
+      Assert.IsFalse(httpMgr.IsStatefulContext);
+      Assert.IsFalse(httpMgr.IsValid); //because no httpcontext exists
+
+      //in this scenario the appliclication context should choose the asynclocal as the 
+      var appContext = provider.GetRequiredService<ApplicationContext>();
+      Assert.IsNotNull(appContext);
+      Assert.IsTrue(appContext.ContextManager is Csla.Core.ApplicationContextManagerAsyncLocal);
+
     }
 #endif
   }

--- a/Source/Csla.test/AppContext/TestContextManager.cs
+++ b/Source/Csla.test/AppContext/TestContextManager.cs
@@ -24,7 +24,7 @@ namespace Csla.Test.AppContext
       get { return true; }
     }
 
-    public bool IsStatefulRuntime => true;
+    public bool IsStatefulContext => true;
 
     public ApplicationContext ApplicationContext { get; set; }
 


### PR DESCRIPTION
This gets the tests passing in `ApplicationContextTests.CorrectManagerChosen`.  Maybe you'd like to add more?

Other tests failing in the Csla.Generators.CSharp.Tests project that I don't understand.